### PR TITLE
Add dilemma 4x6 json configuration

### DIFF
--- a/Dilemma_4X6.json
+++ b/Dilemma_4X6.json
@@ -1,0 +1,171 @@
+{
+  "name": "Dilemma_4X6",
+  "vendorId": "0xAFC6",
+  "productId": "0xBFC6",
+  "matrix": {
+    "rows": 8,
+    "cols": 6
+  },
+  "customKeycodes": [
+    {
+      "name": "Default DPI Forward",
+      "title": "Default DPI Forward",
+      "shortName": "DPI+"
+    },
+    {
+      "name": "Default DPI Reverse",
+      "title": "Default DPI Reverse",
+      "shortName": "DPI-"
+    },
+    {
+      "name": "Sniping DPI Forward",
+      "title": "Sniping DPI Forward",
+      "shortName": "Sniping+"
+    },
+    {
+      "name": "Sniping DPI Reverse",
+      "title": "Sniping DPI Reverse",
+      "shortName": "Sniping-"
+    },
+    {
+      "name": "Sniping Mode",
+      "title": "Sniping Mode",
+      "shortName": "SnipeMO"
+    },
+    {
+      "name": "Sniping Toggle",
+      "title": "Sniping Toggle",
+      "shortName": "SnipeTG"
+    },
+    {
+      "name": "Dragscroll Mode",
+      "title": "Dragscroll Mode",
+      "shortName": "DragScl"
+    },
+    {
+      "name": "Dragscroll Toggle",
+      "title": "Dragscroll Toggle",
+      "shortName": "DragTog"
+    }
+  ],
+  "keycodes": [
+    "qmk_lighting"
+  ],
+  "menus": [
+    "qmk_rgb_matrix"
+  ],
+  "layouts": {
+    "labels": [
+      "Left Encoder",
+      "Right Encoder"
+    ],
+    "keymap": [
+      [
+        {"x": 2},
+        "0,2",
+        "0,3",
+        {"x": 6},
+        "4,2",
+        "4,3"
+      ],
+      [
+        {"y": -0.75, "x": 4},
+        "0,4",
+        "0,5",
+        {"x": 2},
+        "4,0",
+        "4,1"
+      ],
+      [
+        {"y": -0.75},
+        "0,0",
+        "0,1",
+        {"x": 10},
+        "4,4",
+        "4,5"
+      ],
+      [
+        {"y": -0.5, "x": 2},
+        "1,2",
+        "1,3",
+        {"x": 6},
+        "5,2",
+        "5,3"
+      ],
+      [
+        {"y": -0.75, "x": 4},
+        "1,4",
+        "1,5",
+        {"x": 2},
+        "5,0",
+        "5,1"
+      ],
+      [
+        {"y": -0.75},
+        "1,0",
+        "1,1",
+        {"x": 10},
+        "5,4",
+        "5,5"
+      ],
+      [
+        {"y": -0.5, "x": 2},
+        "2,2",
+        "2,3",
+        {"x": 6},
+        "6,2",
+        "6,3"
+      ],
+      [
+        {"y": -0.75, "x": 4},
+        "2,4",
+        "2,5",
+        {"x": 2},
+        "6,0",
+        "6,1"
+      ],
+      [
+        {"y": -0.75},
+        "2,0",
+        "2,1",
+        {"x": 10},
+        "6,4",
+        "6,5"
+      ],
+      [
+        {"y": -0.5, "x": 2.3},
+        "3,2\n\n\n0,0",
+        {"x": 7.28},
+        "7,3\n\n\n1,0"
+      ],
+      [
+        {"y": -0.5, "x": 3.3},
+        "3,3",
+        {"x": 5.28},
+        "7,2"
+      ],
+      [
+        {"y": -0.5, "x": 2.3},
+        "3,2\n\n\n0,1\n\n\n\n\n\ne0",
+        {"x": 7.28},
+        "7,3\n\n\n1,1\n\n\n\n\n\ne1"
+      ],
+      [
+        {"r": 30, "rx": 6.5, "ry": 4.5, "y": -0.5, "x": -1, "h": 1.5},
+        "3,5"
+      ],
+      [
+        {"y": -0.5, "x": -2},
+        "3,4"
+      ],
+      [
+        {"r": -30, "rx": 13, "ry": 4.25, "y": -3.1, "x": -5, "h": 1.5},
+        "7,0"
+      ],
+      [
+        {"y": -0.55, "x": -4},
+        "7,1"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the `Dilemma_4X6.json` file, providing the keyboard definition for the QMK Configurator. This includes matrix dimensions, custom keycodes, supported keycodes/menus, and the visual layout for the Dilemma_4X6 keyboard.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

---
<a href="https://cursor.com/background-agent?bcId=bc-05c6b154-81ec-49a9-8657-1b7f4069f512">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05c6b154-81ec-49a9-8657-1b7f4069f512">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

